### PR TITLE
[codex] Restore semantic-release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -12,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -29,5 +35,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "exifr": "^7.1.3",
         "findup-sync": "^5.0.0",
         "image-size": "^1.2.0",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.17.23",
         "ora": "^8.1.1"
       },
       "bin": {
@@ -4449,9 +4449,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.0.tgz",
-      "integrity": "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.capitalize": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "exifr": "^7.1.3",
     "findup-sync": "^5.0.0",
     "image-size": "^1.2.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "ora": "^8.1.1"
   },
   "devDependencies": {

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -4,7 +4,6 @@ export default {
     [
       "@semantic-release/commit-analyzer",
       {
-        preset: "conventionalcommits",
         releaseRules: [
           { type: "chore", scope: "deps", release: "patch" },
           { type: "chore", scope: "deps-dev", release: "patch" },


### PR DESCRIPTION
## Summary
- pin `lodash-es` back to `^4.17.23` and update the lockfile to avoid the broken `4.18.0` publish
- remove the unsupported `preset: "conventionalcommits"` option from semantic-release commit analysis
- keep the dependency release rules so `chore(deps)` merges still publish a patch release

## Validation
- `npm run test`
- `npm run build`
- `npx semantic-release --dry-run --no-ci` now gets past commit-analyzer configuration and only stops on missing/invalid publish credentials outside CI

## Context
This fixes the release failure seen after PR #17 merged: the branch had picked up a broken `lodash-es@4.18.0`, and the semantic-release config referenced a preset package that was not installed.